### PR TITLE
Add http prefix to the url if was not provided by users

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -61,6 +61,10 @@ func (h handler) encode(w io.Writer, r *http.Request) (interface{}, int, error) 
 	if url == "" {
 		return nil, http.StatusBadRequest, fmt.Errorf("URL is empty")
 	}
+		
+	if !strings.Contains(url, "http") {
+		url = "http://" + url
+	}
 
 	c, err := h.storage.Save(url)
 	if err != nil {


### PR DESCRIPTION
If a url without http(s) shortens, when trying to redirect, the `redirect()` method can't redirect the browser to original url and just appends original site address to the end of url shortner, like so `http://localhost:8080/www.google.com`.

Of course in real world scenarios, apps front-end with some javascript regex checks fixes this issue. But still you can't always trust what end-users what the enter and always having backend verifications is recommended.

This simple fix makes sure every url stored with `http://` at the beginning. Also I've used `strings.Contains()` method which I think its more performant than regex. And also it only adds `http`, because we can't know if the site uses ssl cetificate or not (https), but this could be enough, because in most of the cases, redirecting http to https handled by websites server configurations.
